### PR TITLE
Fixes to build2 files and sources to make the code compile with modules.

### DIFF
--- a/brot/build/root.build
+++ b/brot/build/root.build
@@ -1,4 +1,4 @@
-cxx.std = latest
+cxx.std = experimental
 
 using cxx
 

--- a/libbrot/build/root.build
+++ b/libbrot/build/root.build
@@ -1,4 +1,4 @@
-cxx.std = latest
+cxx.std = experimental
 
 using cxx
 
@@ -6,6 +6,7 @@ hxx{*}: extension = hpp
 ixx{*}: extension = ipp
 txx{*}: extension = tpp
 cxx{*}: extension = cpp
+mxx{*}: extension = mpp
 
 # The test target for cross-testing (running tests under Wine, etc).
 #

--- a/libbrot/libbrot/brot.cpp
+++ b/libbrot/libbrot/brot.cpp
@@ -1,7 +1,8 @@
+module; // Note: non-interface modules units are not yet supported by MSVC, it triggers a bug where
 #include <ostream>
 #include <stdexcept>
 
-module brot:
+module brot; // Note: non-interface modules units are not yet supported by MSVC, it triggers a bug where
 
 using namespace std;
 

--- a/libbrot/libbrot/brot.mpp
+++ b/libbrot/libbrot/brot.mpp
@@ -1,6 +1,7 @@
-
+module;
 #include <iosfwd>
 #include <string>
+#include <libbrot/export.hpp>
 
 export module brot;
 

--- a/libbrot/libbrot/buildfile
+++ b/libbrot/libbrot/buildfile
@@ -2,7 +2,7 @@ intf_libs = # Interface dependencies.
 impl_libs = # Implementation dependencies.
 #import impl_libs += libhello%lib{hello}
 
-lib{brot}: {hxx ixx txx mxx cxx}{** -version} hxx{version} $impl_libs $intf_libs
+lib{brot}: {hxx ixx txx mxx cxx}{** -version}  $impl_libs $intf_libs # hxx{version}
 
 # Include the generated version header into the distribution (so that we don't
 # pick up an installed one) and don't remove it when cleaning in src (so that

--- a/libbrot/tests/basics/driver.cpp
+++ b/libbrot/tests/basics/driver.cpp
@@ -3,6 +3,9 @@
 #include <stdexcept>
 
 // #include <libbrot/version.hpp>
+// #include <libbrot/brot.hpp>
+
+import brot;
 
 int main ()
 {

--- a/libbrot/tests/basics/driver.cpp
+++ b/libbrot/tests/basics/driver.cpp
@@ -2,8 +2,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <libbrot/version.hpp>
-#include <libbrot/brot.hpp>
+// #include <libbrot/version.hpp>
 
 int main ()
 {

--- a/libbrot/tests/build/root.build
+++ b/libbrot/tests/build/root.build
@@ -1,4 +1,4 @@
-cxx.std = latest
+cxx.std = experimental
 
 using cxx
 


### PR DESCRIPTION
See the comit messages for details.

Some important things:
 - `mxx` is the target type for module interface units. You didn't set the right extension in root.build so build2 wasn't trying to build your module so far (fixed);
 - Beware the final syntax of modules: if you have global-module stuffs (`#include ...`) in your module unit (whatever the kind) you MUST have as the first line `module;` then your includes, then `export module blah;` or `module blah;` then the code of the modules. I suspect your module syntax knowledge is not up to date, it was changed in the last year of standardisation of modules (fixed).
 - You commented the generation of version header but still had it used (fixed).
 - `cxx.std = latest`  is usually fine, but here it would not setup a version of the compiler that actually have module, which is why I "forced" `cxx.std = experimental`. Another way to do this while keeping `cxx.std = latest`, which makes more sense, is to initialize your configuration (or change in the `build/config.build` file) that value `cxx.std = whateverworks` here `whateverworks` would be either `experimental` or `20`.
 - You forgot to use the symbol import/export macros properly, so I fixed it too. You could also replace it by `__symexport` provided by build2, it's FAAARR simpler to use, but specific to build2.